### PR TITLE
Handle popup only with left click

### DIFF
--- a/SGPP/Modules/PopupGiveaway.ts
+++ b/SGPP/Modules/PopupGiveaway.ts
@@ -30,9 +30,11 @@ module ModuleDefinition {
         }
 
         private handlePopupCreate = (dom) => {
-            $('a[href^="/giveaway/"]:not([href$="/entries"],[href$="/comments"],[href$="/winners"])', dom).on("click",(e) => {
-                e.preventDefault();
-                this.handlePopup($(e.currentTarget));
+            $('a[href^="/giveaway/"]:not([href$="/entries"],[href$="/comments"],[href$="/winners"])', dom).on("click", (e) => {
+                if (e.button === 0) {
+                    e.preventDefault();
+                    this.handlePopup($(e.currentTarget));
+                }
             });
         }
 


### PR DESCRIPTION
Handle popup only with left click so it is possible to open giveaway
pages in a new tab/window with a middle click.